### PR TITLE
chore: move methods from plugin into gem for processors base

### DIFF
--- a/lib/treasury/processors/base.rb
+++ b/lib/treasury/processors/base.rb
@@ -3,12 +3,18 @@
 module Treasury
   module Processors
     class Base < ::CoreDenormalization::Processors::Base
+      attr_accessor :object
+
       def form_value(value)
         value
       end
 
       def result_row(value)
         {@object => form_value(value)}
+      end
+
+      def no_action
+        nil
       end
     end
   end


### PR DESCRIPTION
- #object
- #no_action

https://jira.railsc.ru/browse/PC4-15968

переезжает [отсюда](https://github.com/abak-press/cosmos-treasury/blob/orders/release/20160218/spec/support/core_denormalization.rb#L7)
