### PR TITLE
feature: add methods to user processor from project

### DIFF
--- a/lib/treasury/processors/user/base.rb
+++ b/lib/treasury/processors/user/base.rb
@@ -3,7 +3,20 @@
 module Treasury
   module Processors
     module User
-      class Base < ::CoreDenormalization::Processors::User::Base
+      class Base < Treasury::Processors::Base
+        alias :user_id= :object=
+        alias :user_id  :object
+
+        protected
+
+        def init_event_params
+          self.user_id = extract_user
+          raise ArgumentError, "User ID expected to be Integer, #{@event.inspect}" unless user_id
+        end
+
+        def extract_user
+          @event.raw_data[:user_id] || @event.raw_data[:id]
+        end
       end
     end
   end


### PR DESCRIPTION
Зачем это надо:
Получается не верное наследование классов
`Processors::Base` наследуеться от проекта
`Processors::User::Base` насоелдуется от проекта, а должен от `Treasury::Processors::Base`
и получается теряется метод object_value который есть только в геме
https://github.com/abak-press/treasury/blob/master/lib/treasury/processors/base.rb#L12
