### PR TITLE
feature: move ReinitializeObjectJob into gem

### DIFF
--- a/app/jobs/treasury/reinitialize_object_job.rb
+++ b/app/jobs/treasury/reinitialize_object_job.rb
@@ -1,0 +1,11 @@
+module Treasury
+  class ReinitializeObjectJob
+    include Resque::Integration
+    queue :base
+    unique
+
+    def self.execute(field_name, object_id)
+      field_name.constantize.reinitialize_object(object_id)
+    end
+  end
+end

--- a/lib/treasury/backwards.rb
+++ b/lib/treasury/backwards.rb
@@ -63,6 +63,7 @@ module CoreDenormalization
   end
 
   ROOT_REDIS_KEY = ::Treasury::ROOT_REDIS_KEY
+  ReinitializeObjectJob = ::Treasury::ReinitializeObjectJob
 end
 
 module Denormalization

--- a/lib/treasury/fields/base.rb
+++ b/lib/treasury/fields/base.rb
@@ -470,6 +470,14 @@ module Treasury
         ActiveRecord::Base.connection
       end
 
+      # Public: Перзапись объекта
+      #
+      # Должно быть перекрыто для нужного поля.
+      #
+      def self.reinitialize_object(object_id)
+        raise NotImplementedError
+      end
+
       private
 
       attr_accessor :state_updated_at


### PR DESCRIPTION
https://jira.railsc.ru/browse/USERS-143

Отзывы принесли в пульс джобу ReinitializeObjectJob https://github.com/abak-press/pulscen/blob/master/vendor/plugins/core_denormalization/app/jobs/core_denormalization/reinitialize_object_job.rb
Чтобы не править зависиомсть в геме, добавляю еще один backwards =)
Реализация метода reinitialize_object в базовом классе филда взята с близко