### PR TITLE
feature: redis.keys -> redis.scan when resetting data

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
     command: bash
     depends_on:
       - db
+      - redis
     volumes:
       - .:/app
       - ssh_data:/ssh:ro
@@ -20,6 +21,10 @@ services:
     image: abakpress/postgres:$POSTGRES_IMAGE_TAG
     environment:
       - POSTGRES_DB=docker
+
+  redis:
+      image: redis:3-alpine
+      command: 'redis-server --appendonly yes --bind 0.0.0.0'
 
 volumes:
   ssh_data:

--- a/spec/internal/config/initializers/treasury.rb
+++ b/spec/internal/config/initializers/treasury.rb
@@ -1,4 +1,4 @@
 Treasury.configure do |config|
-  config.redis = MockRedis.new
+  config.redis = Redis.new(host: :redis)
   config.job_error_notifications = ['test@test.com']
 end

--- a/spec/lib/treasury/storage/redis/base_spec.rb
+++ b/spec/lib/treasury/storage/redis/base_spec.rb
@@ -1,36 +1,52 @@
-# coding: utf-8
-
 describe Treasury::Storage::Redis::Base do
   let(:options) { {:key => 'key'} }
-  let(:singleton_write_session) { described_class.new(options).send(:write_session) }
   let(:storage) { described_class.new(options) }
-  let(:another_storage) { described_class.new(options) }
+  let(:redis) { Treasury.configuration.redis }
 
   before { allow_any_instance_of(described_class).to receive(:default_id) }
-  before { allow(described_class).to receive(:new_redis_session) { MockRedis.new } }
 
   describe 'is used for writing a single connection to Redis' do
+    let(:singleton_write_session) { described_class.new(options).send(:write_session) }
+    let(:another_storage) { described_class.new(options) }
+
     subject { singleton_write_session }
 
     it { is_expected.to be storage.send(:write_session) }
     it { is_expected.to be another_storage.send(:write_session) }
   end
 
-  describe '#rollback_transaction' do
-    let(:write_session) { storage.send(:write_session) }
-
+  context '#reset_data' do
     before do
-      storage.start_transaction
-      write_session.set('key', 'value')
+      stub_const 'Treasury::Storage::Redis::Base::RESET_FIELDS_BATCH_SIZE', 2
+
+      redis.hset 'denormalization:key:1', 'k1', 'v1'
+      redis.hset 'denormalization:key:1', 'k2', 'v2'
+      redis.hset 'denormalization:key:1', 'k3', 'v3'
+
+      redis.hset 'denormalization:key:2', 'k1', 'v1'
+      redis.hset 'denormalization:key:2', 'k2', 'v2'
+      redis.hset 'denormalization:key:2', 'k3', 'v3'
+
+      redis.hset 'denormalization:key:3', 'k1', 'v1'
+      redis.hset 'denormalization:key:3', 'k2', 'v2'
+      redis.hset 'denormalization:key:3', 'k3', 'v3'
+
+      storage.reset_data(nil, %w(k1 k2))
     end
 
-    after { storage.rollback_transaction }
-
-    it { expect(write_session.exists('key')).to be_truthy }
-
     it do
-      storage.rollback_transaction
-      expect(write_session.exists('key')).to be_falsey
+      expect(redis.hexists('denormalization:key:1', 'k1')).to be_falsey
+      expect(redis.hexists('denormalization:key:1', 'k2')).to be_falsey
+
+      expect(redis.hexists('denormalization:key:2', 'k1')).to be_falsey
+      expect(redis.hexists('denormalization:key:2', 'k2')).to be_falsey
+
+      expect(redis.hexists('denormalization:key:3', 'k1')).to be_falsey
+      expect(redis.hexists('denormalization:key:3', 'k2')).to be_falsey
+
+      expect(redis.hget('denormalization:key:1', 'k3')).to eq 'v3'
+      expect(redis.hget('denormalization:key:2', 'k3')).to eq 'v3'
+      expect(redis.hget('denormalization:key:3', 'k3')).to eq 'v3'
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,13 +3,12 @@ require 'bundler/setup'
 require 'treasury'
 
 require 'simplecov'
-require 'mock_redis'
 require 'combustion'
 require "factory_girl_rails"
 require 'shoulda-matchers'
 
 SimpleCov.start do
-  minimum_coverage 70
+  minimum_coverage 73.5
 end
 
 Combustion.initialize! :action_mailer, :active_record
@@ -28,4 +27,7 @@ RSpec.configure do |config|
 
   config.filter_run_including focus: true
   config.run_all_when_everything_filtered = true
+
+  config.before(:each) { Treasury.configuration.redis.flushall }
+  config.after(:each) { Treasury.configuration.redis.flushall }
 end

--- a/treasury.gemspec
+++ b/treasury.gemspec
@@ -33,7 +33,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'simplecov'
   spec.add_development_dependency 'combustion', '>= 0.5.3'
   spec.add_development_dependency 'appraisal'
-  spec.add_development_dependency 'mock_redis'
   spec.add_development_dependency 'rspec-given'
   spec.add_development_dependency 'shoulda-matchers'
 end


### PR DESCRIPTION
Перевел процесс сброса данных из редиса при инициализации с использования keys на курсор (scan). keys на продакшене юзать нельзя, фризит сервер.

Быстрее должен процесс сброса происходить, вычитывает все компании с прода пц за 4 минуты, при этом не оказывая особого влияния.

От MockRedis отказался тк от него одни проблемы и он не умеет держать два конекта к одной базе, имеет свои особенности в результате которых работает не как реальный редис.

https://redis.io/commands/scan