### PR TITLE
fix: incorrect order item name in treasury

### DIFF
--- a/lib/treasury/pgq/event.rb
+++ b/lib/treasury/pgq/event.rb
@@ -80,7 +80,7 @@ module Treasury
         return {} if query.nil?
         query.split('&').inject(HashWithIndifferentAccess.new) do |result, item|
           k, v = item.split('=')
-          result.merge!(k => v)
+          result.merge!(k => Rack::Utils.unescape(v))
         end
       end
     end


### PR DESCRIPTION
Проблема, при транслировании наименования позиции заказа получаем:
"Product 1" -> "Product+1"

Тк pgq экранирует проблел в плюсик тут https://github.com/markokr/skytools/blob/master/sql/pgq/triggers/logutriga.c#L224

У нас свой парсер для этого тут https://github.com/abak-press/treasury/blob/master/lib/treasury/pgq/event.rb#L79 но он ничего не нормализует (оптимизация)

Предложенный вариант замедляет работу в полтора раза, есть еще вариант gsub делать, но это тоже не айс
```
       user     system      total        real
Rack
  1.180000   0.000000   1.180000 (  1.181480)
Manual  0.410000   0.000000   0.410000 (  0.411171)
Unescape  0.650000   0.000000   0.650000 (  0.653757)
Gsub +  0.520000   0.000000   0.520000 (  0.511749)

```

```ruby
require 'cgi'
require 'benchmark'
data = 'param1=value1&param2=value2&param3=value3'

def simple_parse_query(query)
  return {} if query.nil?
  query.split('&').inject(HashWithIndifferentAccess.new) do |result, item|
    k, v = item.split('=')
    result.merge!(k => v)
  end
end

def simple_parse_query_with_values_rack_unescape(query)
  return {} if query.nil?
  query.split('&').inject(HashWithIndifferentAccess.new) do |result, item|
    k, v = item.split('=')
    result.merge!(k => Rack::Utils.unescape(v))
  end
end


def simple_parse_query_with_values_gsub_plus(query)
  return {} if query.nil?
  query.split('&').inject(HashWithIndifferentAccess.new) do |result, item|
    k, v = item.split('=')
    result.merge!(k => v.gsub("+", " "))
  end
end
      
n = 50000
Benchmark.bm do |x|
  x.report("Rack") { n.times { Rack::Utils.parse_nested_query(data) } }
  x.report("Manual") { n.times { simple_parse_query(data) } }
  x.report("Unescape") { n.times { simple_parse_query_with_values_unescape(data) } }
  x.report("Gsub +") { n.times { simple_parse_query_with_values_gsub_plus(data) } }
end

```