### PR TITLE
fix: fixup wrong number of args for ActiveRecord::Base.quote_value in rails >= 4.1

### DIFF
--- a/lib/treasury/fields/base.rb
+++ b/lib/treasury/fields/base.rb
@@ -415,7 +415,7 @@ module Treasury
       end
 
       def quote(str)
-        ::ActiveRecord::Base.quote_value(str)
+        ::ActiveRecord::Base.connection.quote(str)
       end
 
       def self.extract_object(params)

--- a/lib/treasury/version.rb
+++ b/lib/treasury/version.rb
@@ -1,3 +1,3 @@
 module Treasury
-  VERSION = '1.8.0'.freeze
+  VERSION = '1.8.1'.freeze
 end


### PR DESCRIPTION
rails 4.0.x - https://github.com/rails/rails/blob/v4.0.13/activerecord/lib/active_record/sanitization.rb#L6
rails >= 4.1.x - https://github.com/rails/rails/blob/v4.1.16/activerecord/lib/active_record/sanitization.rb#L6

Т.к. все равно вызов делегируется к connection, то заменяем сразу на connection.quote.

Затронутый метод используется только для лога вот здесь - https://github.com/abak-press/treasury/blob/2fcaadb1a014697927c9af5b45662d7082439955/lib/treasury/fields/base.rb#L77
В других местах аналогичной проблемы не нашел.